### PR TITLE
Fix window init panic

### DIFF
--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -39,8 +39,7 @@ pub fn run() -> BError {
     println!("Welcome to Lurhook! (engine stub)");
     init_subsystems()?;
 
-    let context = BTermBuilder::new()
-        .with_dimensions(80, 25)
+    let context = BTermBuilder::simple(80, 25)?
         .with_title("Lurhook")
         .build()?;
     let gs = LurhookGame::default();


### PR DESCRIPTION
## Summary
- use `BTermBuilder::simple` to create a console

This prevents a panic that occurred inside bracket-terminal when no console layer was registered.

## Testing
- `cargo test --workspace --quiet`
