### PR TITLE
Add unit test coverage

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -22,3 +22,15 @@ pub enum GameError {
 }
 
 pub type GameResult<T> = Result<T, GameError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn point_new_sets_coordinates() {
+        let p = Point::new(2, 3);
+        assert_eq!(p.x, 2);
+        assert_eq!(p.y, 3);
+    }
+}

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -3,3 +3,13 @@
 pub fn init() {
     println!("Initialized crate: data");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_runs() {
+        init();
+    }
+}

--- a/crates/mapgen/src/lib.rs
+++ b/crates/mapgen/src/lib.rs
@@ -48,4 +48,11 @@ mod tests {
         assert_eq!(map.height, 10);
         assert_eq!(map.tiles.len(), 100);
     }
+
+    #[test]
+    fn index_calculation() {
+        let map = Map::new(10, 10);
+        let idx = map.idx(Point::new(3, 2));
+        assert_eq!(idx, 2 * 10 + 3);
+    }
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -36,4 +36,12 @@ mod tests {
         ui.add_log("test").unwrap();
         assert_eq!(ui.logs.len(), 1);
     }
+
+    #[test]
+    fn refresh_ok() {
+        let mut ui = UIContext::default();
+        ui.add_log("a").unwrap();
+        ui.add_log("b").unwrap();
+        assert!(ui.refresh().is_ok());
+    }
 }


### PR DESCRIPTION
## Summary
- add basic tests for common types, mapgen indexing, UI refresh, and data init

## Testing
- `cargo test --all`