### PR TITLE
Switch from GitLab CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: '1.78'
+          override: true
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Test
+        run: cargo test --all --offline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,0 @@
-image: rust:1.78
-stages:
-  - test
-
-lint_and_test:
-  stage: test
-  script:
-    - cargo clippy -- -D warnings
-    - cargo test --all --offline

--- a/Progress.md
+++ b/Progress.md
@@ -1,7 +1,7 @@
-# Lurhook 開発タスクリスト (GitLab 用)
+# Lurhook 開発タスクリスト (GitHub 用)
 
 > **目的**: `docs/requirements.md` と `docs/designs.md` に基づき、ローカル開発 (オンプレ環境、`cargo run`) を段階的に進めながら品質を結合ポイントで固めていく。
-> **管理方法**: 各項目は GitLab Issue として登録し、以下のチェックリストをコピーして進捗を管理してください。
+> **管理方法**: 各項目は GitHub Issue として登録し、以下のチェックリストをコピーして進捗を管理してください。
 
 ---
 
@@ -27,7 +27,7 @@
 
 * [x] Rust 1.78+ のインストール (`rustup`)
 * [x] リポジトリをクローンし、`cargo run` が "Welcome to Lurhook!" を表示することを確認
-* [x] `.gitlab-ci.yml` を作成し、Ubuntu 最新版で以下を実行
+* [x] `.github/workflows/ci.yml` を作成し、Ubuntu 最新版で以下を実行
 
   * `cargo clippy -- -D warnings`
   * `cargo test --all --offline`
@@ -128,7 +128,7 @@
 * [ ] 各クレートでユニットテストを追加し、80%+ カバレッジ
 * [ ] ゴールデンマスター & スナップショットテスト導入
 * [x] スナップショットテストの改行差異を吸収しクロスプラットフォーム化
-* [ ] GitLab CI を Linux/Windows/macOS + WASM マトリクスに拡張
+* [ ] GitHub Actions を Linux/Windows/macOS + WASM マトリクスに拡張
 * [ ] `cargo clippy -- -D warnings` を CI に組み込み、パフォーマンス回帰テスト(任意)
 
 </details>
@@ -137,10 +137,10 @@
 
 ## 進め方ガイド
 
-1. **Issue 化**: 上記チェック項目を GitLab Issue として登録し、ラベル `foundation` / `world` / `fishing` / `persistence` を付与。
-2. **マイルストーン設定**: M0～M3 を GitLab Milestone に登録し、関連 Issue を紐付ける。
-3. **ブランチ戦略**: Milestone ごとに `feature/m0-*`, `feature/m1-*` などのプレフィックスを付け、`main` ブランチへ MR (Merge Request) ベースで統合。
-4. **レビュー & CI**: MR 作成時に CI が走り、グリーンになればレビュー。レビュー完了後にマージ。
+1. **Issue 化**: 上記チェック項目を GitHub Issue として登録し、ラベル `foundation` / `world` / `fishing` / `persistence` を付与。
+2. **マイルストーン設定**: M0～M3 を GitHub Milestone に登録し、関連 Issue を紐付ける。
+3. **ブランチ戦略**: Milestone ごとに `feature/m0-*`, `feature/m1-*` などのプレフィックスを付け、`main` ブランチへ PR (Pull Request) ベースで統合。
+4. **レビュー & CI**: PR 作成時に CI が走り、グリーンになればレビュー。レビュー完了後にマージ。
 5. **進捗更新**: Issue のチェックボックスを更新し、完了したら `Closed`。
 
 > **メモ**: 本 `task.md` は進捗管理のハブとして README とは分けてリポジトリ直下に配置し、随時更新してください。

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ wasm-pack build --target web
 ## 📝 開発ルール
 
 1. **main ブランチは常にビルド可能**。機能追加は `feature/*` → PR → マージ。
-2. `cargo clippy` & `cargo test` を CI で自動実行。
+2. `cargo clippy` & `cargo test` を GitHub Actions で自動実行。
 3. `devlog/` に mdBook 形式で開発ログを残す（モチベ維持！）。
 
 ## 🤝 コントリビューション


### PR DESCRIPTION
## Summary
- replace GitLab CI pipeline with GitHub Actions workflow
- update Progress document to mention GitHub and PRs
- note GitHub Actions use in README

## Testing
- `cargo test --all --offline`