### PR TITLE
Implement cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,11 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  build-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -20,3 +23,16 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Test
         run: cargo test --all --offline
+
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: '1.78'
+          target: wasm32-unknown-unknown
+          override: true
+      - name: Build (wasm)
+        run: cargo build --all --target wasm32-unknown-unknown --release

--- a/Progress.md
+++ b/Progress.md
@@ -128,8 +128,8 @@
 * [ ] 各クレートでユニットテストを追加し、80%+ カバレッジ
 * [ ] ゴールデンマスター & スナップショットテスト導入
 * [x] スナップショットテストの改行差異を吸収しクロスプラットフォーム化
-* [ ] GitHub Actions を Linux/Windows/macOS + WASM マトリクスに拡張
-* [ ] `cargo clippy -- -D warnings` を CI に組み込み、パフォーマンス回帰テスト(任意)
+* [x] GitHub Actions を Linux/Windows/macOS + WASM マトリクスに拡張
+* [x] `cargo clippy -- -D warnings` を CI に組み込み、パフォーマンス回帰テスト(任意)
 
 </details>
 


### PR DESCRIPTION
## Summary
- expand CI to run on Linux/Windows/macOS and build wasm target
- mark CI improvements as done in progress tracker

## Testing
- `cargo test --all --quiet`