### PR TITLE
Implement tidal current system

### DIFF
--- a/Progress.md
+++ b/Progress.md
@@ -25,7 +25,7 @@
 * [x] **Depth-Specific Spawning:** Map generation now assigns numeric depths to water tiles (0–100m) and spawning filters by each fish type's depth range.
 * [x] **Schooling Behavior:** Implemented a simple group AI so fish of the same species move toward each other when nearby, creating loose schools.
 * [x] **Time-of-Day Activity:** Fish now move faster at Night, tying their behavior to the day-night cycle. Spawning is unchanged for now but the groundwork is in place for time-based variations.
-* [ ] **Tidal Currents Effect:** Simulate ocean currents that influence fish movement patterns. For instance, implement a subtle drift where, during certain periods (tides), all fish positions shift or bias in one direction (and perhaps back again with ebb/flow). This environmental effect would add realism and challenge – the player might find fish have moved with the current, making positioning and timing more important.
+* [x] **Tidal Currents Effect:** Simulate ocean currents that influence fish movement patterns. For instance, implement a subtle drift where, during certain periods (tides), all fish positions shift or bias in one direction (and perhaps back again with ebb/flow). This environmental effect adds realism and challenge – the player might find fish have moved with the current, making positioning and timing more important.
 
 ## UI/UX Improvements
 

--- a/crates/ecology/src/lib.rs
+++ b/crates/ecology/src/lib.rs
@@ -13,12 +13,28 @@ pub struct Fish {
 
 const SCHOOL_RADIUS: i32 = 4;
 
+/// Applies a directional current to all fish positions.
+pub fn apply_current(map: &Map, fishes: &mut [Fish], drift: Point) {
+    if drift.x == 0 && drift.y == 0 {
+        return;
+    }
+    for fish in fishes.iter_mut() {
+        let mut new = Point::new(fish.position.x + drift.x, fish.position.y + drift.y);
+        new.x = new.x.clamp(0, map.width as i32 - 1);
+        new.y = new.y.clamp(0, map.height as i32 - 1);
+        if matches!(map.tiles[map.idx(new)], TileKind::ShallowWater | TileKind::DeepWater) {
+            fish.position = new;
+        }
+    }
+}
+
 /// Updates all fish positions with simple AI.
 pub fn update_fish(
     map: &Map,
     fishes: &mut [Fish],
     rng: &mut RandomNumberGenerator,
     time_of_day: &str,
+    drift: Point,
 ) -> GameResult<()> {
     let speed = if time_of_day == "Night" { 2 } else { 1 };
     for i in 0..fishes.len() {
@@ -52,6 +68,7 @@ pub fn update_fish(
             fishes[i].position = new_pt;
         }
     }
+    apply_current(map, fishes, drift);
     Ok(())
 }
 
@@ -162,7 +179,7 @@ mod tests {
         let mut fish = spawn_fish(&mut map, &types).expect("fish");
         let mut rng = RandomNumberGenerator::seeded(1);
         for _ in 0..20 {
-            update_fish(&map, std::slice::from_mut(&mut fish), &mut rng, "Day")
+            update_fish(&map, std::slice::from_mut(&mut fish), &mut rng, "Day", Point::new(0,0))
                 .unwrap();
             assert!(fish.position.x >= 0 && fish.position.x < map.width as i32);
             assert!(fish.position.y >= 0 && fish.position.y < map.height as i32);
@@ -201,7 +218,7 @@ mod tests {
         let before = (fishes[0].position.x - fishes[1].position.x).abs()
             + (fishes[0].position.y - fishes[1].position.y).abs();
         let mut rng = RandomNumberGenerator::seeded(1);
-        update_fish(&map, &mut fishes, &mut rng, "Day").unwrap();
+        update_fish(&map, &mut fishes, &mut rng, "Day", Point::new(0,0)).unwrap();
         let after = (fishes[0].position.x - fishes[1].position.x).abs()
             + (fishes[0].position.y - fishes[1].position.y).abs();
         assert!(after < before || after == 0);
@@ -225,11 +242,30 @@ mod tests {
         let mut night_fish = Fish { kind: ft.clone(), position: Point::new(5, 5) };
         let mut rng_day = RandomNumberGenerator::seeded(1);
         let mut rng_night = RandomNumberGenerator::seeded(1);
-        update_fish(&map, std::slice::from_mut(&mut day_fish), &mut rng_day, "Day").unwrap();
-        update_fish(&map, std::slice::from_mut(&mut night_fish), &mut rng_night, "Night").unwrap();
+        update_fish(&map, std::slice::from_mut(&mut day_fish), &mut rng_day, "Day", Point::new(0,0)).unwrap();
+        update_fish(&map, std::slice::from_mut(&mut night_fish), &mut rng_night, "Night", Point::new(0,0)).unwrap();
         let day_dist = (day_fish.position.x - 5).abs().max((day_fish.position.y - 5).abs());
         let night_dist = (night_fish.position.x - 5).abs().max((night_fish.position.y - 5).abs());
         assert!(night_dist >= day_dist);
         assert!(night_dist <= 2);
+    }
+
+    #[test]
+    fn current_moves_fish() {
+        let mut map = Map::new(5, 5);
+        for t in map.tiles.iter_mut() {
+            *t = TileKind::ShallowWater;
+        }
+        let ft = FishType {
+            id: "A".into(),
+            name: "A".into(),
+            rarity: 1.0,
+            strength: 1,
+            min_depth: 0,
+            max_depth: 10,
+        };
+        let mut fish = Fish { kind: ft, position: Point::new(2, 2) };
+        apply_current(&map, std::slice::from_mut(&mut fish), Point::new(1, 0));
+        assert_eq!(fish.position, Point::new(3, 2));
     }
 }

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -16,6 +16,7 @@ const VIEW_WIDTH: i32 = 60;
 const VIEW_HEIGHT: i32 = 17;
 const LINE_DAMAGE: i32 = 10;
 const TIME_SEGMENT_TURNS: u32 = 10;
+const TIDE_TURNS: u32 = 20;
 const TIMES: [&str; 4] = ["Dawn", "Day", "Dusk", "Night"];
 const SAVE_PATH: &str = "savegame.ron";
 const CONFIG_PATH: &str = "lurhook.toml";
@@ -92,6 +93,14 @@ impl LurhookGame {
         self.turn += 1;
         let idx = (self.turn / TIME_SEGMENT_TURNS) % TIMES.len() as u32;
         self.time_of_day = TIMES[idx as usize];
+    }
+
+    fn current_drift(&self) -> common::Point {
+        if (self.turn / TIDE_TURNS) % 2 == 0 {
+            common::Point::new(1, 0)
+        } else {
+            common::Point::new(-1, 0)
+        }
     }
     /// Moves the player by the given delta, clamped to screen bounds.
     fn try_move(&mut self, delta: common::Point) {
@@ -363,11 +372,13 @@ impl GameState for LurhookGame {
         self.handle_input(ctx);
         match self.mode {
             GameMode::Exploring => {
+                let drift = self.current_drift();
                 update_fish(
                     &self.map,
                     &mut self.fishes,
                     &mut self.rng,
                     self.time_of_day,
+                    drift,
                 )
                 .expect("fish update");
             }


### PR DESCRIPTION
## Summary
- implement tidal current drift in the ecology system
- expose drift calculation in game-core and apply each tick
- test new current behavior
- mark progress for tidal currents as complete

## Testing
- `cargo test --all --quiet`