### PR TITLE
Fix CI and stabilize fish spawning

### DIFF
--- a/Progress.md
+++ b/Progress.md
@@ -7,6 +7,7 @@
 * [x] **Turn-Based Game Loop:** Integrated the main game loop using the bracket-lib engine. Each tick processes player input and then updates game state (e.g. moves fish) before rendering the map. This ensures a deterministic turn order where exploration mode calls fish AI updates and fishing mode runs the fishing mini-game logic.
 * [x] **Return & Scoring System:** Add a mechanism to **end the fishing run** – for example, letting the player return to the start or press a key to conclude the trip – and then calculate a **final score** based on the fish caught. This involves defining a win/lose condition (e.g. voluntary return or “dropout” if HP or equipment is depleted) and tallying points (using fish rarity/values) to display the results.
 * [x] **Day-Night Cycle:** Added a simple turn-based clock. Each tick advances a counter and updates the `time_of_day` string through Dawn → Day → Dusk → Night in a loop.
+* [x] **CI Stability:** Fixed clippy warnings and flakey tests so GitHub Actions now pass reliably.
 
 ## Fishing Mechanics
 
@@ -25,6 +26,7 @@
 * [x] **Depth-Specific Spawning:** Map generation now assigns numeric depths to water tiles (0–100m) and spawning filters by each fish type's depth range.
 * [x] **Schooling Behavior:** Implemented a simple group AI so fish of the same species move toward each other when nearby, creating loose schools.
 * [x] **Time-of-Day Activity:** Fish now move faster at Night, tying their behavior to the day-night cycle. Spawning is unchanged for now but the groundwork is in place for time-based variations.
+* [x] **Reliable Fish Spawning:** The spawning algorithm now retries until the requested number of fish is placed, preventing intermittent test failures.
 * [ ] **Tidal Currents Effect:** Simulate ocean currents that influence fish movement patterns. For instance, implement a subtle drift where, during certain periods (tides), all fish positions shift or bias in one direction (and perhaps back again with ebb/flow). This environmental effect would add realism and challenge – the player might find fish have moved with the current, making positioning and timing more important.
 
 ## UI/UX Improvements

--- a/crates/ecology/src/lib.rs
+++ b/crates/ecology/src/lib.rs
@@ -84,8 +84,12 @@ pub fn spawn_fish_population(
 
     let mut rng = RandomNumberGenerator::new();
     let mut fishes = Vec::new();
-    for _ in 0..count {
-        let total: f32 = fish_types.iter().map(|f| f.rarity).sum();
+    let total: f32 = fish_types.iter().map(|f| f.rarity).sum();
+    let max_attempts = count * 10;
+    let mut attempts = 0;
+    while fishes.len() < count && attempts < max_attempts && !water.is_empty() {
+        attempts += 1;
+
         let mut roll = rng.range(0.0, total);
         let mut chosen = &fish_types[0];
         for ft in fish_types {
@@ -147,7 +151,7 @@ mod tests {
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../assets/fish.json");
         let types = load_fish_types(path).expect("types");
         let fishes = spawn_fish_population(&mut map, &types, 5).expect("fishes");
-        assert!(!fishes.is_empty());
+        assert_eq!(fishes.len(), 5);
         for f in fishes {
             let depth = map.depth(f.position);
             assert!(depth >= f.kind.min_depth && depth <= f.kind.max_depth);

--- a/crates/game-core/src/input.rs
+++ b/crates/game-core/src/input.rs
@@ -1,5 +1,5 @@
 use bracket_lib::prelude::VirtualKeyCode;
-use common::{GameError, GameResult};
+use common::GameResult;
 
 /// Configuration for keyboard controls.
 #[derive(Clone, Debug)]

--- a/crates/game-core/src/lib.rs
+++ b/crates/game-core/src/lib.rs
@@ -19,7 +19,6 @@ const TIME_SEGMENT_TURNS: u32 = 10;
 const TIMES: [&str; 4] = ["Dawn", "Day", "Dusk", "Night"];
 const SAVE_PATH: &str = "savegame.ron";
 const CONFIG_PATH: &str = "lurhook.toml";
-use data;
 use input::InputConfig;
 
 /// Current game mode.
@@ -36,7 +35,6 @@ pub struct LurhookGame {
     player: Player,
     map: Map,
     fishes: Vec<Fish>,
-    fish_types: Vec<data::FishType>,
     ui: UIContext,
     input: InputConfig,
     depth: i32,
@@ -65,7 +63,6 @@ impl LurhookGame {
             },
             map,
             fishes,
-            fish_types,
             ui: UIContext::default(),
             input: InputConfig::load(CONFIG_PATH)?,
             depth: 0,
@@ -312,7 +309,7 @@ impl LurhookGame {
                 .ok_or_else(|| GameError::Parse(format!("missing {}", key)))?;
             let s = &s[start + key.len()..];
             let end = s
-                .find(|c: char| c == ',' || c == ')')
+                .find(|c: char| [',', ')'].contains(&c))
                 .ok_or_else(|| GameError::Parse(format!("malformed {}", key)))?;
             s[..end]
                 .trim()
@@ -590,7 +587,8 @@ mod tests {
     #[test]
     fn score_calculation() {
         let mut game = LurhookGame::default();
-        let fish = game.fish_types[0].clone();
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../assets/fish.json");
+        let fish = data::load_fish_types(path).expect("types")[0].clone();
         game.player.inventory.push(fish.clone());
         let expected = ((1.0 / fish.rarity) * 10.0) as i32;
         assert_eq!(game.score(), expected);
@@ -599,7 +597,8 @@ mod tests {
     #[test]
     fn end_run_sets_mode() {
         let mut game = LurhookGame::default();
-        let fish = game.fish_types[0].clone();
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../assets/fish.json");
+        let fish = data::load_fish_types(path).expect("types")[0].clone();
         game.player.inventory.push(fish);
         game.end_run();
         assert!(matches!(game.mode, GameMode::End { .. }));

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -12,7 +12,6 @@ pub enum UILayout {
     Inventory,
 }
 use common::GameResult;
-use data;
 
 const LOG_Y: i32 = 17;
 const LOG_WINDOW: i32 = 8;


### PR DESCRIPTION
## Summary
- remove redundant imports causing clippy failure
- ensure fish spawning consistently reaches requested count
- tweak parser code for clippy
- update tests for new spawning behavior
- document CI fix and reliable spawning in Progress.md

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --all`
